### PR TITLE
add backend method

### DIFF
--- a/beaker/cache.py
+++ b/beaker/cache.py
@@ -120,6 +120,9 @@ class _backends(object):
         except ImportError:
             pass
 
+    def add_backend(self, name, manager):
+        self._clsmap[name] = manager
+
 
 # Initialize the basic available backends
 clsmap = _backends(
@@ -326,6 +329,10 @@ class Cache(object):
         except KeyError:
             cache_managers[key] = cache = cls(namespace, **kw)
             return cache
+
+    @classmethod
+    def add_backend(cls, name, manager):
+        clsmap.add_backend(name, manager)
 
     def put(self, key, value, **kw):
         self._get_value(key, **kw).set_value(value)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -12,6 +12,7 @@ from beaker import util
 from beaker.cache import Cache
 from nose import SkipTest
 from beaker.util import skip_if
+import beaker.container as container
 import base64
 import zlib
 
@@ -338,6 +339,12 @@ def _test_upgrade_setitem(dir):
     cache = Cache("test", data_dir=dir, type="dbm")
     assert cache["foo"] == "bar"
     assert cache["foo"] == "bar"
+
+
+def _test_add_backend(dir):
+    Cache.add_backend("dbm2", container.DBMNamespaceManager)
+    # Should not raise exception
+    Cache("test", data_dir=dir, type="dbm2")
 
 
 def teardown():


### PR DESCRIPTION
Add an add backend method.

I think it would be cleaner to add the cassandra_cql extension to the ext folder but adding this is a good thing